### PR TITLE
Setup CD workflow

### DIFF
--- a/.github/workflows/cantina-build.yml
+++ b/.github/workflows/cantina-build.yml
@@ -18,7 +18,7 @@ jobs:
         with:
             java-version: 15
       - name: Unit test with Maven
-        run: mvn test > report.txt
+        run: mvn test -Dartifact_version=dev > report.txt
       - name: Save unit test report
         uses: actions/upload-artifact@v2
         with:
@@ -26,7 +26,7 @@ jobs:
           path: report.txt
         timeout-minutes: 1
       - name: Integration test with Maven
-        run: mvn verify > report.txt
+        run: mvn verify -Dartifact_version=dev > report.txt
       - name: Save integration test report
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/cantina-build_main.yml
+++ b/.github/workflows/cantina-build_main.yml
@@ -1,0 +1,18 @@
+# .github/workflows/cantina-build_main.yml
+name: Cantina build - main branch
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+            java-version: 15
+      - name: Unit and integration test with Maven
+        run: mvn test verify -Dartifact_version=main

--- a/.github/workflows/cantina-deploy.yml
+++ b/.github/workflows/cantina-deploy.yml
@@ -1,0 +1,65 @@
+# .github/workflows/cantina-deploy.yml
+name: Cantina deployment and release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 15
+        uses: actions/setup-java@v1
+        with:
+            java-version: 15
+      - name: Compile app
+        run: mvn compile -Dartifact_version=main
+  tests:
+    runs-on: ubuntu-18.04
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 15
+        uses: actions/setup-java@v1
+        with:
+            java-version: 15
+      - name: Check unit and integration tests
+        run: mvn test verify -Dartifact_version=main
+  deploy:
+    runs-on: ubuntu-18.04
+    needs: [tests]
+    env:
+      PACKAGE_NAME: CantinaServer
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set output
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Set up JDK 15
+        uses: actions/setup-java@v1
+        with:
+            java-version: 15
+      - name: Create JAR package
+        run: mvn package -Dartifact_version=${{ steps.vars.outputs.tag }} -Dmaven.test.skip=true
+      - name: Create a new release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload release asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/${{ env.PACKAGE_NAME }}-${{ steps.vars.outputs.tag }}.jar
+          asset_name: ${{ env.PACKAGE_NAME }}-${{ steps.vars.outputs.tag }}.jar
+          asset_content_type: application/java-archive

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.cicdlectures.menuserver</groupId>
   <artifactId>cantina</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>${artifact_version}</version>
   
   <properties>
     <maven.compiler.source>15</maven.compiler.source>


### PR DESCRIPTION
Setup the CD workflow by:
* Change dynamically the version of the JAR package (modifications in `pom.xml` and `cantina-build.yml`,
* Create the CI on the main branch (without saving the reports),
* Create the CD on a pushed tag and publish the release with the JAR as an asset.